### PR TITLE
Add API endpoint to GET assets for a specified collection and location

### DIFF
--- a/asset_manager/asset_manager/urls.py
+++ b/asset_manager/asset_manager/urls.py
@@ -26,7 +26,7 @@ router = SimpleRouter()
 router.register("api/assets/tag/(?P<id>\d+)", views.AssetPerTagViewSet, 'asset')
 router.register("api/assets/collection/(?P<collection_id>\d+)/tag/(?P<tag_id>\d+)", 
 		views.AssetPerCollectionAndTagViewSet, 'asset')
-router.register("api/assets/collection/(?P<collection_id>\d+)/country/(?P<country_id>\d+)", 
+router.register("api/assets/collection/(?P<collection_id>\d+)/location/(?P<location_id>\d+)", 
 		views.AssetPerCollectionAndCountryViewSet, 'asset')
 router.register("api/assets", views.AssetViewSet)
 router.register("api/collections", views.CollectionViewSet)

--- a/asset_manager/asset_manager/urls.py
+++ b/asset_manager/asset_manager/urls.py
@@ -26,6 +26,8 @@ router = SimpleRouter()
 router.register("api/assets/tag/(?P<id>\d+)", views.AssetPerTagViewSet, 'asset')
 router.register("api/assets/collection/(?P<collection_id>\d+)/tag/(?P<tag_id>\d+)", 
 		views.AssetPerCollectionAndTagViewSet, 'asset')
+router.register("api/assets/collection/(?P<collection_id>\d+)/country/(?P<country_id>\d+)", 
+		views.AssetPerCollectionAndCountryViewSet, 'asset')
 router.register("api/assets", views.AssetViewSet)
 router.register("api/collections", views.CollectionViewSet)
 router.register("api/contributors", views.ContributorViewSet)

--- a/asset_manager/file_manager/views.py
+++ b/asset_manager/file_manager/views.py
@@ -35,8 +35,8 @@ class AssetPerCollectionAndCountryViewSet(ModelViewSet):
 
     def get_queryset(self):
         collection_id = self.kwargs['collection_id']
-        country_id = self.kwargs['country_id']
-        return Asset.objects.filter(collections__id=collection_id).filter(locations__id=country_id)
+        location_id = self.kwargs['location_id']
+        return Asset.objects.filter(collections__id=collection_id).filter(locations__id=location_id)
 
 class ContributorViewSet(ModelViewSet):
     serializer_class = serializers.ContributorSerializer

--- a/asset_manager/file_manager/views.py
+++ b/asset_manager/file_manager/views.py
@@ -29,6 +29,15 @@ class AssetPerCollectionAndTagViewSet(ModelViewSet):
         tag_id = self.kwargs['tag_id']
         return Asset.objects.filter(collections__id=collection_id).filter(tags__id=tag_id)
 
+class AssetPerCollectionAndCountryViewSet(ModelViewSet):
+    serializer_class = serializers.AssetSerializer
+    permission_classes = (IsAuthenticatedOrReadOnly,)
+
+    def get_queryset(self):
+        collection_id = self.kwargs['collection_id']
+        country_id = self.kwargs['country_id']
+        return Asset.objects.filter(collections__id=collection_id).filter(locations__id=country_id)
+
 class ContributorViewSet(ModelViewSet):
     serializer_class = serializers.ContributorSerializer
     queryset = Contributor.objects.all()


### PR DESCRIPTION
@georgemillard one question about this. It looks like we use the word "CountryTag" to describe the model, `countries` for the API endpoint, but `locations` for the property on the Asset model. Should we bring those in line or did you have a rationale for that?

Happy to change the endpoint to refer to `location` instead of `country` before you approve. Let me know what you think.