### PR TITLE
#120 Added Django form validation to catch files that are larger than 100MB

### DIFF
--- a/asset_manager/asset_manager/settings_base.py
+++ b/asset_manager/asset_manager/settings_base.py
@@ -129,3 +129,6 @@ MEDIA_URL = "https://%s/%s/" % (AWS_S3_CUSTOM_DOMAIN, MEDIAFILES_LOCATION)
 
 # Logs
 LOGFILE='logs/logs.txt'
+
+# Custom Variables
+MAX_FILE_SIZE = 100000000 # 100MB Note, if you change this you need to change the file_size.js file.

--- a/asset_manager/file_manager/admin.py
+++ b/asset_manager/file_manager/admin.py
@@ -44,6 +44,10 @@ class AssetAdmin(admin.ModelAdmin):
         set_asset_user_metadata(obj, request.user)
         super(AssetAdmin, self).save_model(request, obj, form, change)
 
+    class Media:
+        js = [
+        'file_manager/js/file_size.js',
+        ]
 
 class AssetInline(admin.TabularInline):
     model = models.Asset

--- a/asset_manager/file_manager/forms.py
+++ b/asset_manager/file_manager/forms.py
@@ -80,7 +80,7 @@ class AssetForm(forms.ModelForm):
             # Catches files that are larger than nginx's max upload size from being uploaded.
             # This should be combined with altering nginx conf file to set a limit that is higher
             # than the one set in Django.
-            MAX_FILE_SIZE = 104857600 # 100MB
+            MAX_FILE_SIZE = 100000000 # 100MB
             readable_size = int(MAX_FILE_SIZE / (1024*1024))
             if (file._size > MAX_FILE_SIZE):
                 raise forms.ValidationError(strings.file_size_exceeded.format(str(readable_size) + "MB"))

--- a/asset_manager/file_manager/forms.py
+++ b/asset_manager/file_manager/forms.py
@@ -81,9 +81,9 @@ class AssetForm(forms.ModelForm):
         # This should be combined with altering nginx conf file to set a limit that is higher
         # than the one set in Django.
         MAX_FILE_SIZE = 104857600 # 100MB
+        readable_size = int(MAX_FILE_SIZE / (1024*1024))
         if (file._size > MAX_FILE_SIZE):
-            raise forms.ValidationError(strings.file_size_exceeded)
-
+            raise forms.ValidationError(strings.file_size_exceeded.format(str(readable_size) + "MB"))
 
         return cleaned_data
 

--- a/asset_manager/file_manager/forms.py
+++ b/asset_manager/file_manager/forms.py
@@ -80,9 +80,9 @@ class AssetForm(forms.ModelForm):
             # Catches files that are larger than nginx's max upload size from being uploaded.
             # This should be combined with altering nginx conf file to set a limit that is higher
             # than the one set in Django.
-            
-            readable_size = int(MAX_FILE_SIZE / (1024*1024))
-            if (file._size > MAX_FILE_SIZE):
+
+            readable_size = int(settings.MAX_FILE_SIZE / (1024*1024))
+            if (file._size > settings.MAX_FILE_SIZE):
                 raise forms.ValidationError(strings.file_size_exceeded.format(str(readable_size) + "MB"))
 
         return cleaned_data

--- a/asset_manager/file_manager/forms.py
+++ b/asset_manager/file_manager/forms.py
@@ -76,6 +76,15 @@ class AssetForm(forms.ModelForm):
             if s3_key in filenames:
                 raise forms.ValidationError(strings.duplicate_file_name_msg.format(file.name, parent, name))
 
+        #### VALIDATE FILE SIZE ####
+        # Catches files that are larger than nginx's max upload size from being uploaded.
+        # This should be combined with altering nginx conf file to set a limit that is higher
+        # than the one set in Django.
+        MAX_FILE_SIZE = 104857600 # 100MB
+        if (file._size > MAX_FILE_SIZE):
+            raise forms.ValidationError(strings.file_size_exceeded)
+
+
         return cleaned_data
 
 

--- a/asset_manager/file_manager/forms.py
+++ b/asset_manager/file_manager/forms.py
@@ -80,7 +80,7 @@ class AssetForm(forms.ModelForm):
             # Catches files that are larger than nginx's max upload size from being uploaded.
             # This should be combined with altering nginx conf file to set a limit that is higher
             # than the one set in Django.
-            MAX_FILE_SIZE = 100000000 # 100MB
+            
             readable_size = int(MAX_FILE_SIZE / (1024*1024))
             if (file._size > MAX_FILE_SIZE):
                 raise forms.ValidationError(strings.file_size_exceeded.format(str(readable_size) + "MB"))

--- a/asset_manager/file_manager/forms.py
+++ b/asset_manager/file_manager/forms.py
@@ -76,14 +76,14 @@ class AssetForm(forms.ModelForm):
             if s3_key in filenames:
                 raise forms.ValidationError(strings.duplicate_file_name_msg.format(file.name, parent, name))
 
-        #### VALIDATE FILE SIZE ####
-        # Catches files that are larger than nginx's max upload size from being uploaded.
-        # This should be combined with altering nginx conf file to set a limit that is higher
-        # than the one set in Django.
-        MAX_FILE_SIZE = 104857600 # 100MB
-        readable_size = int(MAX_FILE_SIZE / (1024*1024))
-        if (file._size > MAX_FILE_SIZE):
-            raise forms.ValidationError(strings.file_size_exceeded.format(str(readable_size) + "MB"))
+            #### VALIDATE FILE SIZE ####
+            # Catches files that are larger than nginx's max upload size from being uploaded.
+            # This should be combined with altering nginx conf file to set a limit that is higher
+            # than the one set in Django.
+            MAX_FILE_SIZE = 104857600 # 100MB
+            readable_size = int(MAX_FILE_SIZE / (1024*1024))
+            if (file._size > MAX_FILE_SIZE):
+                raise forms.ValidationError(strings.file_size_exceeded.format(str(readable_size) + "MB"))
 
         return cleaned_data
 

--- a/asset_manager/file_manager/models.py
+++ b/asset_manager/file_manager/models.py
@@ -207,7 +207,7 @@ class Asset(S3_Object):
         verbose_name='Type (CE100 Resources only)'
     )
 
-    filetype = models.CharField(max_length=64, null=True)
+    filetype = models.CharField(max_length=128, null=True)
     uploaded_at = models.DateTimeField(null=True)
     last_edit_at = models.DateTimeField(null=True)
 

--- a/asset_manager/file_manager/static/file_manager/js/file_size.js
+++ b/asset_manager/file_manager/static/file_manager/js/file_size.js
@@ -1,0 +1,30 @@
+// If Jquery not imported, use django's built in version and set it to use $
+if (!$) {
+    $ = django.jQuery;
+}
+
+$(document).ready(function() {
+  $input = $('#id_file');
+  MAX_FILE_SIZE = 100000000;
+
+  // Watch for file changes
+  $input.on("change", function(e) {
+    file_size = this.files[0].size;
+    if (file_size >= MAX_FILE_SIZE) {
+      // File too big, add error message
+      $("<ul>")
+        .addClass("errorlist filesize_exceeded")
+        .append($("<li>")
+          .text("The file you have selected is too large, please choose a file under 100MB and try again."))
+        .insertBefore("#id_file");
+      // Remove file from input
+      $input.replaceWith($input.val('').clone(true));
+      $('#id_file').css({"border":"1px solid #ba2121", "border-radius":"5px"});
+    }
+    else {
+      // File not too big, remove error message and styling
+      $(".filesize_exceeded").remove();
+      $('#id_file').css("border", "none");
+    }
+  });
+});

--- a/asset_manager/file_manager/strings.py
+++ b/asset_manager/file_manager/strings.py
@@ -22,6 +22,8 @@ with the same name: "{1}". Please choose unique names for each {0}.'
 
 missing_parent_msg = 'No Parent Folder has been selected. Please choose a Parent Folder.'
 
+file_size_exceeded = 'The file you have chosen is too large, please select a file that is less than 100MB.'
+
 # string constants
 VALID_NAME_FORMAT = '^[a-zA-Z0-9-_ ]+$'
 VALID_FILE_NAME_FORMAT = '^[a-zA-Z0-9-_.]+$'

--- a/asset_manager/file_manager/strings.py
+++ b/asset_manager/file_manager/strings.py
@@ -22,7 +22,7 @@ with the same name: "{1}". Please choose unique names for each {0}.'
 
 missing_parent_msg = 'No Parent Folder has been selected. Please choose a Parent Folder.'
 
-file_size_exceeded = 'The file you have chosen is too large, please select a file that is less than 100MB.'
+file_size_exceeded = 'The file you have chosen is too large, please select a file that is less than {0}'
 
 # string constants
 VALID_NAME_FORMAT = '^[a-zA-Z0-9-_ ]+$'


### PR DESCRIPTION
Django form validation will prevent any files larger than 100MB being uploaded, however this should be combined with changing the nginx.conf file to allow larger files. 

As Django first uploads the file then validates, the nginx config needs to be changed to prevent the default 413 error. 
The line`client_max_body_size 100M;` can be added/modified in the nginx.conf file to set a custom max upload size.