### PR TITLE
Changed Type name to Content Type, and made mandatory

### DIFF
--- a/asset_manager/file_manager/models.py
+++ b/asset_manager/file_manager/models.py
@@ -203,8 +203,7 @@ class Asset(S3_Object):
     type_field = models.CharField(
         max_length=2,
         choices = TYPE_CHOICES,
-        blank=True,
-        verbose_name='Type (CE100 Resources only)'
+        verbose_name='Content Type'
     )
 
     filetype = models.CharField(max_length=128, null=True)


### PR DESCRIPTION
As 'Type' is going to be potentially more useful going forward and being made required for all Assets, I have omitted the relation to CE100/ CELLO only.

Q: Does this field need to be higher up when creating/editing an Asset now that it is of more importance?