### PR TITLE
#125 Setup Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *.cover
+cover/
 .hypothesis/
 
 # Translations

--- a/asset_manager/.coveragerc
+++ b/asset_manager/.coveragerc
@@ -2,7 +2,6 @@
 
 [run]
 branch = true
-disable_warnings = true
 
 omit = 
     *__init__.py

--- a/asset_manager/.coveragerc
+++ b/asset_manager/.coveragerc
@@ -1,21 +1,28 @@
 # .coveragerc to control coverage.py
+
 [run]
-branch = false
+branch = true
+disable_warnings = true
+
 omit = 
     *__init__.py
    */migrations/*
    asset_manager/settings*
+   manage.py
+   */tests/*
+   */tests.py
+   */scripts/*
+   *.pyc
 
-include = 
-    ../../asset-manager/*
-    file_manager/*
-    api/*
-    user_interface/*
-    asset_manager/*
-
+source = 
+    file_manager/
+    api/
+    asset_manager/
+    user_interface/
 
 [report]
 show_missing = True
 
 [html]
 title = DAM Unit Tests Report
+directory = cover

--- a/asset_manager/.coveragerc
+++ b/asset_manager/.coveragerc
@@ -1,0 +1,14 @@
+# .coveragerc to control coverage.py
+[run]
+branch = True
+omit = 
+    *__init__.py
+    file_manager/migrations/*
+    asset_manager/settings*
+    file_manager/scripts/*
+
+[report]
+show_missing = True
+
+[html]
+title = DAM Unit Tests Report

--- a/asset_manager/.coveragerc
+++ b/asset_manager/.coveragerc
@@ -1,11 +1,18 @@
 # .coveragerc to control coverage.py
 [run]
-branch = True
+branch = false
 omit = 
     *__init__.py
-    file_manager/migrations/*
-    asset_manager/settings*
-    file_manager/scripts/*
+   */migrations/*
+   asset_manager/settings*
+
+include = 
+    ../../asset-manager/*
+    file_manager/*
+    api/*
+    user_interface/*
+    asset_manager/*
+
 
 [report]
 show_missing = True

--- a/asset_manager/asset_manager/settings_base.py
+++ b/asset_manager/asset_manager/settings_base.py
@@ -59,7 +59,6 @@ TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 NOSE_ARGS = [
     '--with-coverage',
     '--cover-html',
-    '--cover-package=asset_manager,file_manager,api,user_interface',
     '--cover-erase',
 ]
 

--- a/asset_manager/asset_manager/settings_base.py
+++ b/asset_manager/asset_manager/settings_base.py
@@ -54,6 +54,15 @@ ROOT_URLCONF = 'asset_manager.urls'
 
 FORM_RENDERER = 'django.forms.renderers.TemplatesSetting'
 
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+
+NOSE_ARGS = [
+    '--with-coverage',
+    '--cover-html',
+    '--cover-package=asset_manager,file_manager,api,user_interface',
+    '--cover-erase',
+]
+
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',

--- a/asset_manager/asset_manager/settings_base.py
+++ b/asset_manager/asset_manager/settings_base.py
@@ -54,14 +54,6 @@ ROOT_URLCONF = 'asset_manager.urls'
 
 FORM_RENDERER = 'django.forms.renderers.TemplatesSetting'
 
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-
-NOSE_ARGS = [
-    '--with-coverage',
-    '--cover-html',
-    '--cover-erase',
-]
-
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',

--- a/asset_manager/requirements.txt
+++ b/asset_manager/requirements.txt
@@ -2,6 +2,7 @@ boto3==1.4.4
 botocore==1.5.58
 certifi==2017.4.17
 chardet==3.0.4
+coverage==4.5.1
 Django==1.11.5
 django-extensions==1.7.9
 django-model-utils==3.0.0
@@ -14,7 +15,10 @@ idna==2.5
 jdcal==1.3
 jmespath==0.9.3
 openpyxl==2.4.8
+pexpect==4.3.1
+pipdeptree==0.10.1
 psycopg2==2.7.1
+ptyprocess==0.5.2
 PyJWT==1.5.0
 python-dateutil==2.6.0
 pytz==2017.2


### PR DESCRIPTION
## Tests & Coverage 
To run all the tests and calculate the coverage data, run:
`coverage run manage.py test`

You can also specify an app and it will run the app's tests and calculate coverage based on this:
`coverage run manage.py test api`

To then see the coverage, you can view it in the terminal, with `coverage report`.
The other option is an interactive html file with `coverage html`, then run `open cover/index.html` to open it in the browser. 

You can also at this stage specify how much of the report/html you wish to see, by adding the files after, ie:
`coverage report api/*.py` will generate a report only showing the files inside the api folder and which are python `py` files.

### Additional Info
**Coverage output**
I have included the checking of branches in the report, whilst this results in a lower percentage of coverage, it is more comprehensive in that it checks the logical flow of the code - as opposed to the standard statement method.

**django_nose**
I tested a package called `django_nose`, which integrates djangos standard test methods with coverage, however, this package is now unsupported and although it meant tests and coverage reports could be run from one command (`python manage.py test`) the results were inconsistent. 

**coverage api**
Coverage does have an API which can be used instead, and could be useful when we automate this process more. 