### PR TITLE
Add option Other to content type field

### DIFF
--- a/asset_manager/file_manager/models.py
+++ b/asset_manager/file_manager/models.py
@@ -199,11 +199,12 @@ class Asset(S3_Object):
         (REPORT, 'REPORT'),
         (VIDEO, 'VIDEO'),
         (WORKSHOP_SUMMARY, 'WORKSHOP SUMMARY'),
+        ('OT', 'OTHER') # change this line to use OTHER which already exists on dev
     )
     type_field = models.CharField(
+        default='OT',
         max_length=2,
         choices = TYPE_CHOICES,
-        blank=True,
         verbose_name='Type (CE100 Resources only)'
     )
 


### PR DESCRIPTION
Hotfix to add the "Other" field to content types. I've changed as little as possible (such as making changes to the `verbose_name`) in order to avoid merge conflicts with develop. 

Note that this is a PR into master!